### PR TITLE
Fix datadog provider configuration

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -48,7 +48,7 @@ locals {
 }
 
 module "datadog_configuration" {
-  source  = "../../datadog-configuration/modules/datadog_keys"
+  source  = "github.com/cloudposse-terraform-components/aws-datadog-credentials//src/modules/datadog_keys?ref=tags/v1.535.2"
   context = module.this.context
 }
 


### PR DESCRIPTION
## what
* Replace relative path for datadog creds module with git reference to the component

## why
* After we split monorepo we can not use relative paths for component references


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the source location of the Datadog configuration module to use a remote repository reference instead of a local path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->