### PR TITLE
fix(terraform): pin helm provider to `~> 2.7`

### DIFF
--- a/src/versions.tf
+++ b/src/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.7"
+      version = ">= 2.0.0, < 3.0.0"
     }
     utils = {
       source  = "cloudposse/utils"

--- a/src/versions.tf
+++ b/src/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.7"
+      version = "~> 2.7"
     }
     utils = {
       source  = "cloudposse/utils"


### PR DESCRIPTION
## what

This pull request makes a minor update to the Terraform provider version specification for Helm in the `src/versions.tf` file. The version constraint has been changed from a broad range to a more restrictive compatible range.

* Changed the Helm provider version constraint from `>= 2.7` to `~> 2.7` in `src/versions.tf`, ensuring only compatible 2.x releases are used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Helm provider version constraints to narrow the supported range for improved compatibility and predictability.
  * This change reduces unexpected upgrades and helps ensure consistent deployments across environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->