### PR TITLE
fix: use `jsonencode` for `datadog.tags` value

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -132,7 +132,7 @@ module "datadog_agent" {
     {
       name  = "datadog.tags"
       type  = "auto"
-      value = yamlencode(local.datadog_tags)
+      value = jsonencode(tolist(local.datadog_tags))
     },
     {
       name  = "datadog.clusterName"


### PR DESCRIPTION
## what

> [!NOTE]
> Credit to @arcaven for the discovery

- Replace `yamlencode()` with `jsonencode()` for the `datadog.tags` helm set value.

## why

- The `yamlencode()` function produces multi-line YAML that helm's `type = "auto"` parser misinterprets, mangling newline-dash sequences (`\n-`) into tag values. This corrupts Datadog host tags with `_n-` suffixes (e.g., `namespace:e98p_n-` instead of `namespace:e98p`), breaking host maps, dashboards, log filtering, and monitors. JSON array format is parsed correctly by helm.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration encoding format for agent module settings to improve compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->