### PR TITLE
fix: correct datadog.tags env var formatting

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -132,7 +132,7 @@ module "datadog_agent" {
     {
       name  = "datadog.tags"
       type  = "auto"
-      value = jsonencode(tolist(local.datadog_tags))
+      value = "{${join(",", [for tag in local.datadog_tags : tag])}}"
     },
     {
       name  = "datadog.clusterName"


### PR DESCRIPTION
## what

This pull request makes a minor adjustment to how Datadog tags are formatted for the `datadog_agent` module. The change modifies the encoding of tags to use a string with comma-separated values inside curly braces, rather than JSON encoding.

* Changed the `value` assignment for `datadog.tags` to use a curly-brace-wrapped, comma-separated string instead of `jsonencode`. (`src/main.tf`)

## why

- Replace jsonencode with manual join to ensure tags are formatted as expected for Datadog Agent environment variable. This fixes issues with tag parsing in the agent.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Datadog agent configuration formatting with no functional impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->