### PR TITLE
fix: resolve deep_map_merge conditional type mismatch

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -20,7 +20,7 @@ locals {
     lower(k) => v
   }
 
-  deep_map_merge = local.cluster_checks_enabled ? module.datadog_cluster_check_yaml_config[0].map_configs : {}
+  deep_map_merge = local.cluster_checks_enabled ? module.datadog_cluster_check_yaml_config[0].map_configs : tomap({})
   datadog_cluster_checks = {
     for k, v in local.deep_map_merge :
     k => merge(v, {


### PR DESCRIPTION
## what

Convert the false branch of the `deep_map_merge` local in `src/main.tf` from a bare empty object literal (`{}`) to `tomap({})`, so both branches of the conditional are maps.

```diff
-  deep_map_merge = local.cluster_checks_enabled ? module.datadog_cluster_check_yaml_config[0].map_configs : {}
+  deep_map_merge = local.cluster_checks_enabled ? module.datadog_cluster_check_yaml_config[0].map_configs : tomap({})
```

## why

The conditional had inconsistent result types between its branches:

- true branch: `module.datadog_cluster_check_yaml_config[0].map_configs`, a typed map
- false branch: `{}`, a bare empty object

Terraform cannot unify a map with an empty object, so evaluation fails with `Inconsistent conditional result types` whenever `cluster_checks_enabled` is `false` (the common case when cluster checks are not configured).

Converting the false branch to `tomap({})` makes both branches maps, and the conditional resolves cleanly. This is the minimal type-unifying change; behavior is unchanged when cluster checks are enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of cluster check configuration when the feature is turned off.
  * Ensures an empty configuration is treated with the correct map type, preventing invalid values from being used during processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->